### PR TITLE
Add Live Support landing page UI

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,0 +1,769 @@
+:root {
+  --primary: #2563eb;
+  --primary-dark: #1d4ed8;
+  --secondary: #f97316;
+  --background: #f8fafc;
+  --surface: #ffffff;
+  --text: #0f172a;
+  --text-muted: #475569;
+  --border: #e2e8f0;
+  --shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+  --radius: 18px;
+}
+
+body.dark {
+  --background: #0f172a;
+  --surface: #111c34;
+  --text: #e2e8f0;
+  --text-muted: #94a3b8;
+  --border: #1e293b;
+  --shadow: 0 18px 40px rgba(15, 23, 42, 0.6);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", sans-serif;
+  background: var(--background);
+  color: var(--text);
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  color: var(--primary);
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.container {
+  width: min(1120px, 92vw);
+  margin: 0 auto;
+}
+
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: rgba(248, 250, 252, 0.9);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--border);
+}
+
+body.dark .topbar {
+  background: rgba(15, 23, 42, 0.9);
+}
+
+.topbar .container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 0;
+}
+
+.topbar nav {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+}
+
+.topbar nav a {
+  font-weight: 500;
+  color: var(--text-muted);
+}
+
+.topbar nav a:hover,
+.topbar nav a:focus {
+  color: var(--primary);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.brand h1 {
+  font-size: 1.3rem;
+  margin: 0;
+}
+
+.brand p {
+  color: var(--text-muted);
+  margin: 2px 0 0 0;
+}
+
+.logo {
+  display: grid;
+  place-items: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, var(--primary), var(--secondary));
+  color: #fff;
+  font-weight: 700;
+  letter-spacing: 1px;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 20px;
+  border-radius: 999px;
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn-primary {
+  background: var(--primary);
+  color: #fff;
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.25);
+}
+
+.btn-primary:hover,
+.btn-primary:focus {
+  background: var(--primary-dark);
+  transform: translateY(-1px);
+}
+
+.btn-secondary {
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--primary);
+}
+
+.btn-secondary:hover,
+.btn-secondary:focus {
+  background: rgba(37, 99, 235, 0.18);
+}
+
+.hero {
+  padding: 96px 0;
+}
+
+.hero__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 56px;
+  align-items: center;
+}
+
+.hero__content h2 {
+  font-size: clamp(2.4rem, 5vw, 3.5rem);
+  margin-bottom: 16px;
+}
+
+.hero__content p {
+  color: var(--text-muted);
+  font-size: 1.05rem;
+  margin-bottom: 24px;
+}
+
+.hero__actions {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 32px;
+}
+
+.hero__stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.hero__stats strong {
+  display: block;
+  font-size: 1.8rem;
+}
+
+.hero__stats span {
+  color: var(--text-muted);
+}
+
+.hero__mockup {
+  display: flex;
+  justify-content: center;
+}
+
+.chat-window {
+  width: min(100%, 380px);
+  background: var(--surface);
+  border-radius: 28px;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+
+.chat-window header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.9), rgba(249, 115, 22, 0.9));
+  color: #fff;
+}
+
+.chat-window header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.chat-window header small {
+  opacity: 0.85;
+}
+
+.chat-window header button {
+  background: rgba(15, 23, 42, 0.22);
+  color: #fff;
+  border: none;
+  width: 28px;
+  height: 28px;
+  border-radius: 12px;
+  font-size: 1.3rem;
+  cursor: pointer;
+}
+
+.chat-body {
+  padding: 24px;
+  display: grid;
+  gap: 18px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.message {
+  padding: 16px;
+  border-radius: 18px;
+  position: relative;
+}
+
+.message .name {
+  font-weight: 600;
+  display: block;
+  margin-bottom: 6px;
+}
+
+.message p {
+  margin: 0;
+}
+
+.message time {
+  display: block;
+  margin-top: 10px;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.message--agent {
+  background: rgba(37, 99, 235, 0.08);
+  border: 1px solid rgba(37, 99, 235, 0.12);
+}
+
+.message--user {
+  background: rgba(249, 115, 22, 0.08);
+  border: 1px solid rgba(249, 115, 22, 0.12);
+}
+
+.chat-input {
+  display: flex;
+  padding: 16px 20px 20px;
+  gap: 12px;
+  border-top: 1px solid var(--border);
+  background: rgba(148, 163, 184, 0.08);
+}
+
+.chat-input input {
+  flex: 1;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 12px 18px;
+  font-size: 0.95rem;
+  background: var(--surface);
+  color: inherit;
+}
+
+.section {
+  padding: 96px 0;
+}
+
+.section--alt {
+  background: rgba(37, 99, 235, 0.04);
+}
+
+.section__header {
+  text-align: center;
+  margin-bottom: 48px;
+}
+
+.section__header h2 {
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  margin: 0 0 12px;
+}
+
+.section__header p {
+  color: var(--text-muted);
+  margin: 0;
+  max-width: 640px;
+  margin-inline: auto;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 28px;
+}
+
+.card {
+  background: var(--surface);
+  border-radius: var(--radius);
+  padding: 32px;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+}
+
+.card h3 {
+  margin-top: 0;
+  margin-bottom: 12px;
+}
+
+.card p {
+  color: var(--text-muted);
+  margin-bottom: 18px;
+}
+
+.card ul {
+  padding-left: 18px;
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.layout-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 28px;
+}
+
+.layout-card {
+  background: var(--surface);
+  border-radius: var(--radius);
+  padding: 28px;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 18px;
+}
+
+.layout-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.badge {
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--primary);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.badge--green {
+  background: rgba(34, 197, 94, 0.18);
+  color: #166534;
+}
+
+.badge--purple {
+  background: rgba(147, 51, 234, 0.18);
+  color: #6d28d9;
+}
+
+.ticket-list {
+  display: grid;
+  gap: 16px;
+}
+
+.ticket {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  align-items: flex-start;
+  padding: 20px;
+  border-radius: 16px;
+  background: rgba(37, 99, 235, 0.05);
+  border: 1px solid rgba(37, 99, 235, 0.15);
+}
+
+.ticket h4 {
+  margin: 0 0 6px;
+}
+
+.ticket p {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.status {
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+.status--high {
+  background: rgba(239, 68, 68, 0.16);
+  color: #b91c1c;
+}
+
+.status--medium {
+  background: rgba(249, 115, 22, 0.18);
+  color: #9a3412;
+}
+
+.status--low {
+  background: rgba(34, 197, 94, 0.18);
+  color: #166534;
+}
+
+.layout-card--wide {
+  grid-column: span 2;
+}
+
+.chat-preview {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 24px;
+}
+
+.chat-preview__conversation {
+  display: grid;
+  gap: 16px;
+  padding: 20px;
+  border-radius: 18px;
+  border: 1px solid var(--border);
+  background: rgba(37, 99, 235, 0.06);
+}
+
+.chat-preview__sidebar {
+  display: grid;
+  gap: 16px;
+  align-content: start;
+}
+
+.chat-preview__sidebar dl {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+}
+
+.chat-preview__sidebar dt {
+  font-weight: 600;
+}
+
+.chat-preview__sidebar dd {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.resources {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+}
+
+.resource-card {
+  background: var(--surface);
+  border-radius: var(--radius);
+  padding: 28px;
+  border: 1px solid var(--border);
+  display: grid;
+  gap: 12px;
+  box-shadow: var(--shadow);
+}
+
+.resource-link {
+  font-weight: 600;
+  color: var(--primary);
+}
+
+.analytics {
+  display: grid;
+  gap: 32px;
+  align-items: center;
+}
+
+.analytics__chart {
+  background: var(--surface);
+  border-radius: var(--radius);
+  padding: 28px;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+}
+
+.analytics__stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 18px;
+  padding: 0;
+  list-style: none;
+}
+
+.analytics__stats strong {
+  font-size: 1.5rem;
+}
+
+.analytics__stats span {
+  color: var(--text-muted);
+}
+
+.testimonials {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.06), rgba(249, 115, 22, 0.08));
+}
+
+.testimonials__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 24px;
+}
+
+.testimonials blockquote {
+  margin: 0;
+  padding: 32px;
+  background: var(--surface);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 18px;
+}
+
+.testimonials blockquote p {
+  font-size: 1.05rem;
+  color: var(--text-muted);
+}
+
+.testimonials blockquote footer {
+  display: grid;
+  gap: 4px;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.pricing__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+}
+
+.price-card {
+  background: var(--surface);
+  border-radius: var(--radius);
+  padding: 32px;
+  border: 1px solid var(--border);
+  display: grid;
+  gap: 16px;
+  text-align: center;
+  box-shadow: var(--shadow);
+}
+
+.price-card--featured {
+  border: 2px solid var(--primary);
+  transform: translateY(-12px);
+}
+
+.price {
+  font-size: 1.8rem;
+  font-weight: 700;
+}
+
+.price-card ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 8px;
+  color: var(--text-muted);
+}
+
+.faq__list {
+  display: grid;
+  gap: 16px;
+}
+
+.faq-item {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+
+.faq-item__question {
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  padding: 22px 28px;
+  font-size: 1rem;
+  font-weight: 600;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: pointer;
+}
+
+.faq-item__answer {
+  max-height: 0;
+  overflow: hidden;
+  padding: 0 28px;
+  transition: max-height 0.3s ease, padding 0.3s ease;
+}
+
+.faq-item.open .faq-item__answer {
+  max-height: 160px;
+  padding: 0 28px 22px;
+}
+
+.cta {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(249, 115, 22, 0.12));
+}
+
+.cta__content {
+  display: grid;
+  gap: 28px;
+  align-items: center;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.cta__form {
+  background: var(--surface);
+  border-radius: var(--radius);
+  padding: 28px;
+  border: 1px solid var(--border);
+  display: grid;
+  gap: 16px;
+  box-shadow: var(--shadow);
+}
+
+.form-field {
+  display: grid;
+  gap: 8px;
+}
+
+.form-field label {
+  font-weight: 600;
+}
+
+.form-field input,
+.form-field select {
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: inherit;
+}
+
+.form-field input:focus,
+.form-field select:focus,
+.chat-input input:focus {
+  outline: 2px solid rgba(37, 99, 235, 0.4);
+  outline-offset: 2px;
+}
+
+.form-message {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  min-height: 1.2em;
+}
+
+.floating-chat {
+  position: fixed;
+  right: 32px;
+  bottom: 32px;
+  padding: 16px 22px;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, var(--primary), var(--secondary));
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 20px 40px rgba(37, 99, 235, 0.35);
+}
+
+.footer {
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 56px 0 32px;
+}
+
+.footer__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 24px;
+  margin-bottom: 32px;
+}
+
+.footer a {
+  color: #e2e8f0;
+  opacity: 0.7;
+}
+
+.footer a:hover {
+  opacity: 1;
+}
+
+.footer__copy {
+  margin: 0;
+  text-align: center;
+  opacity: 0.6;
+}
+
+@media (max-width: 900px) {
+  .topbar nav {
+    display: none;
+  }
+
+  .hero {
+    padding-top: 72px;
+  }
+
+  .layout-card--wide {
+    grid-column: auto;
+  }
+
+  .chat-preview {
+    grid-template-columns: 1fr;
+  }
+
+  .floating-chat {
+    right: 20px;
+    bottom: 20px;
+  }
+}
+
+@media (max-width: 640px) {
+  .hero__stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .chat-window {
+    border-radius: 20px;
+  }
+
+  .btn {
+    width: 100%;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,451 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Live Support - Hệ thống hỗ trợ khách hàng trực tuyến</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+  <header class="topbar">
+    <div class="container">
+      <div class="brand">
+        <span class="logo">LS</span>
+        <div>
+          <h1>Live Support</h1>
+          <p>Hệ thống hỗ trợ khách hàng trực tuyến thông minh</p>
+        </div>
+      </div>
+      <nav>
+        <a href="#tinh-nang">Tính năng</a>
+        <a href="#giao-dien">Giao diện</a>
+        <a href="#bang-gia">Bảng giá</a>
+        <a href="#tai-nguyen">Tài nguyên</a>
+        <a href="#lien-he" class="btn btn-primary">Liên hệ demo</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero">
+      <div class="container hero__grid">
+        <div class="hero__content">
+          <h2>Đồng hành cùng đội ngũ chăm sóc khách hàng 24/7</h2>
+          <p>
+            Thiết kế Live Support giúp đội ngũ hỗ trợ xử lý yêu cầu đa kênh, tự động hoá quy trình và nâng cao mức độ hài lòng của khách hàng trong từng tương tác.
+          </p>
+          <div class="hero__actions">
+            <a href="#giao-dien" class="btn btn-primary">Khám phá giao diện</a>
+            <button id="toggleTheme" class="btn btn-secondary">Chuyển chế độ tối</button>
+          </div>
+          <div class="hero__stats">
+            <div>
+              <strong>50%</strong>
+              <span>Giảm thời gian phản hồi</span>
+            </div>
+            <div>
+              <strong>92%</strong>
+              <span>Tỷ lệ hài lòng khách hàng</span>
+            </div>
+            <div>
+              <strong>+30</strong>
+              <span>Tích hợp sẵn sàng</span>
+            </div>
+          </div>
+        </div>
+        <div class="hero__mockup">
+          <div class="chat-window" aria-live="polite">
+            <header>
+              <div>
+                <h3>Hỗ trợ trực tuyến</h3>
+                <small>Đang hoạt động</small>
+              </div>
+              <button id="closeChat" aria-label="Thu nhỏ cửa sổ chat">×</button>
+            </header>
+            <div class="chat-body">
+              <div class="message message--agent">
+                <span class="name">Agent Mai</span>
+                <p>Xin chào Lâm, em có thể hỗ trợ anh thiết lập chatbot ngay hôm nay.</p>
+                <time>09:12</time>
+              </div>
+              <div class="message message--user">
+                <span class="name">Bạn</span>
+                <p>Tuyệt vời! Anh cần tự động phân loại ticket.</p>
+                <time>09:13</time>
+              </div>
+              <div class="message message--agent">
+                <span class="name">Agent Mai</span>
+                <p>Anh có thể bật tính năng gợi ý câu trả lời và SLA theo mức độ ưu tiên.</p>
+                <time>09:14</time>
+              </div>
+            </div>
+            <form id="chatForm" class="chat-input" aria-label="Gửi tin nhắn hỗ trợ">
+              <input type="text" id="chatMessage" placeholder="Nhập tin nhắn..." required>
+              <button type="submit" class="btn btn-primary">Gửi</button>
+            </form>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="tinh-nang" class="section">
+      <div class="container section__header">
+        <h2>Bộ tính năng toàn diện</h2>
+        <p>Kết nối đa kênh, quản trị tri thức, tự động hoá và phân tích nâng cao trong một nền tảng thống nhất.</p>
+      </div>
+      <div class="container card-grid">
+        <article class="card">
+          <h3>Hộp thư đa kênh</h3>
+          <p>Nhập mọi yêu cầu từ Email, Livechat, Zalo, Facebook và tổng đài VoIP vào một hộp thư thống nhất.</p>
+          <ul>
+            <li>Định tuyến thông minh theo kỹ năng</li>
+            <li>SLA tuỳ chỉnh theo từng nhóm khách hàng</li>
+            <li>Tự động phân loại ticket bằng AI</li>
+          </ul>
+        </article>
+        <article class="card">
+          <h3>Trung tâm tri thức</h3>
+          <p>Tạo, quản lý và đo lường hiệu quả của bài viết hướng dẫn giúp khách hàng tự phục vụ.</p>
+          <ul>
+            <li>Soạn thảo markdown, gợi ý nội dung</li>
+            <li>Gợi ý bài viết liên quan trong chat</li>
+            <li>Báo cáo lượt xem, tỷ lệ thoát</li>
+          </ul>
+        </article>
+        <article class="card">
+          <h3>Tự động hoá quy trình</h3>
+          <p>Xây dựng kịch bản chăm sóc và phản hồi tự động với trình kéo thả trực quan.</p>
+          <ul>
+            <li>Trigger theo sự kiện và dữ liệu</li>
+            <li>Gợi ý trả lời dựa trên lịch sử tương tác</li>
+            <li>Hợp nhất với CRM hiện có</li>
+          </ul>
+        </article>
+        <article class="card">
+          <h3>Phân tích hiệu suất</h3>
+          <p>Tăng trưởng dịch vụ dựa trên số liệu thời gian thực và bảng điều khiển tuỳ biến.</p>
+          <ul>
+            <li>Báo cáo SLA, CSAT, NPS</li>
+            <li>Dashboard trực quan kéo thả</li>
+            <li>Cảnh báo khi vượt ngưỡng</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+
+    <section id="giao-dien" class="section section--alt">
+      <div class="container section__header">
+        <h2>Giao diện điều phối hỗ trợ</h2>
+        <p>Hình dung rõ ràng các phân hệ chính của Live Support với bảng điều khiển hiện đại.</p>
+      </div>
+      <div class="container layout-grid">
+        <div class="layout-card">
+          <header>
+            <h3>Bảng điều khiển</h3>
+            <span class="badge">Realtime</span>
+          </header>
+          <ul>
+            <li>Tổng quan SLA, CSAT, backlog</li>
+            <li>Biểu đồ tình trạng kênh</li>
+            <li>Top agent theo hiệu suất</li>
+          </ul>
+        </div>
+        <div class="layout-card">
+          <header>
+            <h3>Hàng chờ ticket</h3>
+            <span class="badge badge--green">AI Assist</span>
+          </header>
+          <div class="ticket-list" role="list">
+            <article class="ticket" role="listitem">
+              <div>
+                <h4>#2568 - Thanh toán bị từ chối</h4>
+                <p>Khách hàng báo lỗi khi thanh toán qua thẻ tín dụng.</p>
+              </div>
+              <span class="status status--high">Khẩn</span>
+            </article>
+            <article class="ticket" role="listitem">
+              <div>
+                <h4>#2570 - Cập nhật thông tin tài khoản</h4>
+                <p>Yêu cầu chỉnh sửa thông tin doanh nghiệp.</p>
+              </div>
+              <span class="status status--medium">Cao</span>
+            </article>
+            <article class="ticket" role="listitem">
+              <div>
+                <h4>#2573 - Không nhận được email xác nhận</h4>
+                <p>Hệ thống gửi email chậm trong giờ cao điểm.</p>
+              </div>
+              <span class="status status--low">Thấp</span>
+            </article>
+          </div>
+        </div>
+        <div class="layout-card layout-card--wide">
+          <header>
+            <h3>Phòng chat trực tiếp</h3>
+            <span class="badge badge--purple">Co-browsing</span>
+          </header>
+          <div class="chat-preview">
+            <div class="chat-preview__conversation">
+              <div class="message message--agent">
+                <span class="name">Agent Linh</span>
+                <p>Chào anh, em vừa xem log và phát hiện lỗi API.</p>
+              </div>
+              <div class="message message--user">
+                <span class="name">Khách hàng</span>
+                <p>Cảm ơn em, anh đang cần cập nhật gấp.</p>
+              </div>
+            </div>
+            <aside class="chat-preview__sidebar">
+              <h4>Thông tin khách hàng</h4>
+              <dl>
+                <div>
+                  <dt>Gói dịch vụ</dt>
+                  <dd>Professional</dd>
+                </div>
+                <div>
+                  <dt>CSAT trung bình</dt>
+                  <dd>4.7 / 5</dd>
+                </div>
+                <div>
+                  <dt>Ticket mở</dt>
+                  <dd>03</dd>
+                </div>
+              </dl>
+              <button class="btn btn-secondary">Mở hồ sơ đầy đủ</button>
+            </aside>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="tai-nguyen" class="section">
+      <div class="container section__header">
+        <h2>Tài nguyên hỗ trợ đội ngũ chăm sóc</h2>
+        <p>Sẵn sàng triển khai nhanh chóng với quy trình chuẩn và tài liệu đầy đủ.</p>
+      </div>
+      <div class="container resources">
+        <div class="resource-card">
+          <h3>Onboarding 14 ngày</h3>
+          <p>Checklist triển khai chuẩn, đào tạo agent và cấu hình tự động hoá.</p>
+          <a href="#" class="resource-link">Tải checklist</a>
+        </div>
+        <div class="resource-card">
+          <h3>Thư viện kịch bản</h3>
+          <p>30+ kịch bản chăm sóc khách hàng cho các ngành B2C &amp; B2B.</p>
+          <a href="#" class="resource-link">Xem thư viện</a>
+        </div>
+        <div class="resource-card">
+          <h3>API &amp; SDK</h3>
+          <p>Tích hợp nhanh chóng với CRM, Billing, Data Warehouse.</p>
+          <a href="#" class="resource-link">Xem tài liệu</a>
+        </div>
+      </div>
+    </section>
+
+    <section class="section section--alt">
+      <div class="container section__header">
+        <h2>Chỉ số vận hành nổi bật</h2>
+      </div>
+      <div class="container analytics">
+        <div class="analytics__chart">
+          <canvas id="slaChart" role="img" aria-label="Biểu đồ SLA"></canvas>
+        </div>
+        <ul class="analytics__stats">
+          <li>
+            <strong>3 phút</strong>
+            <span>Thời gian phản hồi lần đầu trung bình</span>
+          </li>
+          <li>
+            <strong>89%</strong>
+            <span>Ticket xử lý tự động bằng chatbot</span>
+          </li>
+          <li>
+            <strong>4.8 / 5</strong>
+            <span>CSAT qua live chat</span>
+          </li>
+          <li>
+            <strong>+120%</strong>
+            <span>Tỷ lệ giữ chân khách hàng</span>
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="section testimonials">
+      <div class="container section__header">
+        <h2>Khách hàng nói gì về Live Support</h2>
+      </div>
+      <div class="container testimonials__grid">
+        <blockquote>
+          <p>“Live Support giúp đội ngũ của tôi tiết kiệm 40% thời gian xử lý ticket và tăng trải nghiệm khách hàng rõ rệt.”</p>
+          <footer>
+            <span>Mai Anh</span>
+            <span>Head of Customer Success - FinTechX</span>
+          </footer>
+        </blockquote>
+        <blockquote>
+          <p>“Sau 2 tuần triển khai, chúng tôi đã tích hợp chatbot hỗ trợ 24/7 và giảm tải cho tổng đài viên.”</p>
+          <footer>
+            <span>Đức Long</span>
+            <span>Giám đốc vận hành - EduNext</span>
+          </footer>
+        </blockquote>
+        <blockquote>
+          <p>“Dashboard trực quan giúp ban lãnh đạo theo dõi SLA thời gian thực và đưa ra quyết định nhanh chóng.”</p>
+          <footer>
+            <span>Thuỷ Tiên</span>
+            <span>Customer Care Lead - RetailOne</span>
+          </footer>
+        </blockquote>
+      </div>
+    </section>
+
+    <section id="bang-gia" class="section pricing">
+      <div class="container section__header">
+        <h2>Bảng giá linh hoạt</h2>
+        <p>Lựa chọn gói dịch vụ phù hợp với quy mô và mục tiêu vận hành của doanh nghiệp.</p>
+      </div>
+      <div class="container pricing__grid">
+        <div class="price-card">
+          <h3>Starter</h3>
+          <p class="price">2.5 triệu / tháng</p>
+          <ul>
+            <li>5 agent</li>
+            <li>Live chat + Email</li>
+            <li>Thư viện tri thức cơ bản</li>
+            <li>Báo cáo tiêu chuẩn</li>
+          </ul>
+          <button class="btn btn-secondary">Dùng thử</button>
+        </div>
+        <div class="price-card price-card--featured">
+          <h3>Professional</h3>
+          <p class="price">5.9 triệu / tháng</p>
+          <ul>
+            <li>20 agent</li>
+            <li>Chatbot AI + Omnichannel</li>
+            <li>Tự động hoá quy trình</li>
+            <li>Dashboard tuỳ chỉnh</li>
+          </ul>
+          <button class="btn btn-primary">Đăng ký</button>
+        </div>
+        <div class="price-card">
+          <h3>Enterprise</h3>
+          <p class="price">Liên hệ</p>
+          <ul>
+            <li>SLA theo thoả thuận</li>
+            <li>Tích hợp chuyên sâu</li>
+            <li>Đội ngũ triển khai chuyên biệt</li>
+            <li>Security &amp; SSO nâng cao</li>
+          </ul>
+          <button class="btn btn-secondary">Nhận tư vấn</button>
+        </div>
+      </div>
+    </section>
+
+    <section class="section faq">
+      <div class="container section__header">
+        <h2>Câu hỏi thường gặp</h2>
+      </div>
+      <div class="container faq__list" id="faqList">
+        <article class="faq-item">
+          <button class="faq-item__question">Live Support tích hợp được những kênh nào?</button>
+          <div class="faq-item__answer">
+            <p>Hệ thống hỗ trợ live chat, email, mạng xã hội, tổng đài và ứng dụng OTT như Zalo, Viber.</p>
+          </div>
+        </article>
+        <article class="faq-item">
+          <button class="faq-item__question">Mất bao lâu để triển khai?</button>
+          <div class="faq-item__answer">
+            <p>Thời gian trung bình 2-4 tuần, tuỳ vào mức độ tích hợp và tuỳ chỉnh quy trình.</p>
+          </div>
+        </article>
+        <article class="faq-item">
+          <button class="faq-item__question">Có hỗ trợ tuỳ chỉnh thương hiệu không?</button>
+          <div class="faq-item__answer">
+            <p>Toàn bộ widget chat, email template, knowledge base đều cho phép tuỳ chỉnh màu sắc, logo và domain.</p>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section id="lien-he" class="section cta">
+      <div class="container cta__content">
+        <div>
+          <h2>Sẵn sàng nâng cấp trải nghiệm khách hàng?</h2>
+          <p>Đăng ký demo để đội ngũ chuyên gia hỗ trợ bạn xây dựng trung tâm chăm sóc khách hàng hiện đại.</p>
+        </div>
+        <form id="contactForm" class="cta__form">
+          <div class="form-field">
+            <label for="fullName">Họ và tên</label>
+            <input type="text" id="fullName" name="fullName" required>
+          </div>
+          <div class="form-field">
+            <label for="company">Doanh nghiệp</label>
+            <input type="text" id="company" name="company" required>
+          </div>
+          <div class="form-field">
+            <label for="email">Email công việc</label>
+            <input type="email" id="email" name="email" required>
+          </div>
+          <div class="form-field">
+            <label for="teamSize">Quy mô đội ngũ hỗ trợ</label>
+            <select id="teamSize" name="teamSize" required>
+              <option value="">Chọn quy mô</option>
+              <option value="1-5">1 - 5 người</option>
+              <option value="6-20">6 - 20 người</option>
+              <option value="21-50">21 - 50 người</option>
+              <option value="50+">Trên 50 người</option>
+            </select>
+          </div>
+          <button type="submit" class="btn btn-primary">Đăng ký demo</button>
+          <p id="formMessage" class="form-message" role="status" aria-live="polite"></p>
+        </form>
+      </div>
+    </section>
+  </main>
+
+  <button class="floating-chat" id="floatingChatButton" aria-label="Mở hộp thoại hỗ trợ">
+    <span>Chat hỗ trợ</span>
+  </button>
+
+  <footer class="footer">
+    <div class="container footer__grid">
+      <div>
+        <strong>Live Support</strong>
+        <p>Kết nối khách hàng và doanh nghiệp qua mọi điểm chạm.</p>
+      </div>
+      <div>
+        <h4>Sản phẩm</h4>
+        <ul>
+          <li><a href="#tinh-nang">Tính năng</a></li>
+          <li><a href="#bang-gia">Bảng giá</a></li>
+          <li><a href="#tai-nguyen">Tài nguyên</a></li>
+        </ul>
+      </div>
+      <div>
+        <h4>Hỗ trợ</h4>
+        <ul>
+          <li><a href="#faq">FAQ</a></li>
+          <li><a href="#">Trung tâm trợ giúp</a></li>
+          <li><a href="#">Chính sách bảo mật</a></li>
+        </ul>
+      </div>
+      <div>
+        <h4>Kết nối</h4>
+        <ul>
+          <li><a href="mailto:support@livesupport.vn">support@livesupport.vn</a></li>
+          <li><a href="tel:+842873000000">(+84) 2873 000 000</a></li>
+          <li><a href="#">LinkedIn</a> · <a href="#">Facebook</a></li>
+        </ul>
+      </div>
+    </div>
+    <p class="footer__copy">© 2024 Live Support. All rights reserved.</p>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="js/app.js"></script>
+</body>
+</html>

--- a/js/app.js
+++ b/js/app.js
@@ -1,0 +1,170 @@
+const body = document.body;
+const toggleThemeButton = document.getElementById('toggleTheme');
+const floatingChatButton = document.getElementById('floatingChatButton');
+const chatWindow = document.querySelector('.chat-window');
+const closeChatButton = document.getElementById('closeChat');
+const chatForm = document.getElementById('chatForm');
+const chatMessageInput = document.getElementById('chatMessage');
+const chatBody = document.querySelector('.chat-body');
+const contactForm = document.getElementById('contactForm');
+const formMessage = document.getElementById('formMessage');
+const faqList = document.getElementById('faqList');
+
+const THEME_KEY = 'live-support-theme';
+
+function applyStoredTheme() {
+  const storedTheme = localStorage.getItem(THEME_KEY);
+  if (storedTheme === 'dark') {
+    body.classList.add('dark');
+    toggleThemeButton.textContent = 'Chuyển chế độ sáng';
+  }
+}
+
+function toggleTheme() {
+  const isDark = body.classList.toggle('dark');
+  toggleThemeButton.textContent = isDark ? 'Chuyển chế độ sáng' : 'Chuyển chế độ tối';
+  localStorage.setItem(THEME_KEY, isDark ? 'dark' : 'light');
+}
+
+function appendMessage({ author, text, time, type }) {
+  const message = document.createElement('div');
+  message.className = `message message--${type}`;
+  message.innerHTML = `
+    <span class="name">${author}</span>
+    <p>${text}</p>
+    <time>${time}</time>
+  `;
+  chatBody.appendChild(message);
+  chatBody.scrollTop = chatBody.scrollHeight;
+}
+
+function handleChatSubmit(event) {
+  event.preventDefault();
+  const message = chatMessageInput.value.trim();
+  if (!message) return;
+
+  const now = new Date();
+  const time = now.toLocaleTimeString('vi-VN', {
+    hour: '2-digit',
+    minute: '2-digit'
+  });
+
+  appendMessage({
+    author: 'Bạn',
+    text: message,
+    time,
+    type: 'user'
+  });
+
+  chatMessageInput.value = '';
+
+  setTimeout(() => {
+    appendMessage({
+      author: 'Agent ảo',
+      text: 'Cảm ơn bạn đã chia sẻ, mình sẽ cập nhật thông tin và phản hồi sớm nhất!',
+      time,
+      type: 'agent'
+    });
+  }, 900);
+}
+
+function toggleChatWindow(open) {
+  chatWindow.style.display = open ? 'grid' : 'none';
+}
+
+function initFAQAccordion() {
+  faqList.querySelectorAll('.faq-item__question').forEach((button) => {
+    button.addEventListener('click', () => {
+      const item = button.closest('.faq-item');
+      const isOpen = item.classList.contains('open');
+      faqList.querySelectorAll('.faq-item').forEach((faq) => faq.classList.remove('open'));
+      if (!isOpen) {
+        item.classList.add('open');
+      }
+    });
+  });
+}
+
+function handleContactSubmit(event) {
+  event.preventDefault();
+  const formData = new FormData(contactForm);
+  const name = formData.get('fullName');
+  formMessage.textContent = `${name}, cảm ơn bạn đã đăng ký! Chúng tôi sẽ liên hệ trong 24 giờ.`;
+  contactForm.reset();
+}
+
+function initChart() {
+  const ctx = document.getElementById('slaChart');
+  if (!ctx) return;
+
+  new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: ['Thứ 2', 'Thứ 3', 'Thứ 4', 'Thứ 5', 'Thứ 6', 'Thứ 7', 'CN'],
+      datasets: [
+        {
+          label: 'SLA - Thời gian phản hồi (phút)',
+          data: [12, 10, 8, 7, 6, 9, 11],
+          borderColor: '#2563eb',
+          backgroundColor: 'rgba(37, 99, 235, 0.15)',
+          fill: true,
+          tension: 0.4,
+          pointRadius: 4,
+          pointBackgroundColor: '#2563eb'
+        },
+        {
+          label: 'Mục tiêu SLA',
+          data: [10, 10, 10, 10, 10, 10, 10],
+          borderColor: '#f97316',
+          borderDash: [6, 6],
+          tension: 0.2,
+          pointRadius: 0
+        }
+      ]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: {
+          labels: {
+            color: getComputedStyle(document.documentElement).getPropertyValue('--text')
+          }
+        }
+      },
+      scales: {
+        x: {
+          ticks: {
+            color: getComputedStyle(document.documentElement).getPropertyValue('--text-muted')
+          },
+          grid: {
+            color: 'rgba(148, 163, 184, 0.15)'
+          }
+        },
+        y: {
+          ticks: {
+            color: getComputedStyle(document.documentElement).getPropertyValue('--text-muted')
+          },
+          grid: {
+            color: 'rgba(148, 163, 184, 0.15)'
+          }
+        }
+      }
+    }
+  });
+}
+
+applyStoredTheme();
+toggleThemeButton.addEventListener('click', toggleTheme);
+floatingChatButton.addEventListener('click', () => toggleChatWindow(true));
+closeChatButton.addEventListener('click', () => toggleChatWindow(false));
+chatForm.addEventListener('submit', handleChatSubmit);
+contactForm.addEventListener('submit', handleContactSubmit);
+initFAQAccordion();
+initChart();
+
+if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+  document.querySelectorAll('*').forEach((el) => {
+    el.style.transition = 'none';
+  });
+}


### PR DESCRIPTION
## Summary
- build a multi-section landing page for the Live Support customer service app with hero content, product features, analytics, pricing, FAQ, and CTA
- add responsive styling with dark mode support and polished component layouts for chat windows, dashboards, and resource cards
- implement client-side interactions for theme toggling, chat simulation, FAQ accordion, SLA chart rendering, and contact form confirmation

## Testing
- Manual testing: opened index.html in a browser to verify layout and interactive behaviors

------
https://chatgpt.com/codex/tasks/task_e_68e4ea4e216c832daa3626b4682a5b3a